### PR TITLE
fix(dc-chain): add dcload-serial missing headers

### DIFF
--- a/dc-chain/Dockerfile2
+++ b/dc-chain/Dockerfile2
@@ -29,6 +29,7 @@ RUN apk --update add --no-cache \
         elfutils-dev \
         libjpeg-turbo-dev \
         libpng-dev \
+        linux-headers \
         python3 \
         && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
asm/ioctls.h header is required to compile dc-tool-ser and is not available in the current dc-chain image. This patch adds the linux-header package so that one can include "<asm/ioctls.h>" in dcload-serial's dctool.c.

note: dc-tool-ser includes still need to be patched to compile flawlessly on alpine.

update: patch merged for dc-tool-ser, see https://github.com/KallistiOS/dcload-serial/pull/33